### PR TITLE
Fixed the bug of navbar links and activated overlay of sponsor cards

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -290,6 +290,7 @@ p{
 }
 
 .sponsor-card {
+  position: relative;
   display: inline-block;
   margin: 20px;
   transition: transform 0.3s;


### PR DESCRIPTION
Fixes #55 
Solved a bug which was happening due to a common mistake: As we all know that whenever we want to give absolute position to any element, we must make sure that its nearest ancestor is positioned non-static. 

Now both the navbar links and the sponsor card overlays have become functional. As you can see clearly in the picture shown below :-
![image](https://github.com/yash19sinha/coffee-bean/assets/119471995/8a2a470c-b1c7-4be1-8824-08a79d0026c8)
