### PR TITLE
Fixed the overflow of heading in the price section.

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -838,3 +838,4 @@ border-radius: 10px;
 background-color: #876445;
 border-radius: 10px;
 }
+

--- a/index.html
+++ b/index.html
@@ -273,7 +273,7 @@
 
         <div class="card">
           <div class="card-header">
-            <span class="shop-item-title text-truncate">
+            <span class="shop-item-title ">
               <h3>DOUBLE ESPRESSO</h3>
             </span>
           </div>


### PR DESCRIPTION
Fixes #82 
![image](https://github.com/yash19sinha/coffee-bean/assets/119471995/61c9c921-30db-47f9-97d6-bc953abb746d)

Fixed the overflow of heading(in price section) that was happening when the width is between 1000px to 1300px.
Thank You